### PR TITLE
fix: remove unnecessary packages

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,8 +2,6 @@ importers:
   .:
     specifiers: {}
   projects/components:
-    dependencies:
-      sirv-cli: 0.4.6
     devDependencies:
       '@babel/core': 7.10.4
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
@@ -14,7 +12,6 @@ importers:
       '@storybook/addons': 5.3.19
       '@storybook/svelte': 5.3.19_df785a49c63f27f0cae6178fd5639aee
       babel-loader: 8.1.0_@babel+core@7.10.4
-      classnames: 2.2.6
       rollup: 1.32.1
       rollup-plugin-livereload: 1.3.0
       rollup-plugin-svelte: 5.2.3_rollup@1.32.1+svelte@3.24.0
@@ -31,12 +28,10 @@ importers:
       '@storybook/addons': ^5.3.19
       '@storybook/svelte': ^5.3.19
       babel-loader: ^8.1.0
-      classnames: ^2.2.6
       rollup: ^1.20.0
       rollup-plugin-livereload: ^1.0.0
       rollup-plugin-svelte: ^5.2.2
       rollup-plugin-terser: ^5.1.2
-      sirv-cli: ^0.4.4
       svelte: ^3.23.2
       svelte-loader: ^2.13.6
   projects/site:
@@ -3394,12 +3389,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==
-  /console-clear/1.1.1:
-    dev: false
-    engines:
-      node: '>=4'
-    resolution:
-      integrity: sha512-pMD+MVR538ipqkG5JXeOEbKWS5um1H4LUUccUQG68qpeqBYbzYy79Gh55jkd2TtPdRfUaLWdv6LPP//5Zt0aPQ==
   /console-control-strings/1.1.0:
     dev: true
     resolution:
@@ -4774,12 +4763,6 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==
-  /get-port/3.2.0:
-    dev: false
-    engines:
-      node: '>=4'
-    resolution:
-      integrity: sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=
   /get-stream/4.1.0:
     dependencies:
       pump: 3.0.0
@@ -5970,12 +5953,6 @@ packages:
       graceful-fs: 4.2.4
     resolution:
       integrity: sha1-QIhDO0azsbolnXh4XY6W9zugJDk=
-  /kleur/3.0.3:
-    dev: false
-    engines:
-      node: '>=6'
-    resolution:
-      integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
   /lazy-ass/1.6.0:
     dev: true
     engines:
@@ -6130,12 +6107,6 @@ packages:
       node: '>=8.9.0'
     resolution:
       integrity: sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==
-  /local-access/1.0.1:
-    dev: false
-    engines:
-      node: '>=6'
-    resolution:
-      integrity: sha512-ykt2pgN0aqIy6KQC1CqdWTWkmUwNgaOS6dcpHVjyBJONA+Xi7AtSB1vuxC/U/0tjIP3wcRudwQk1YYzUvzk2bA==
   /locate-path/2.0.0:
     dependencies:
       p-locate: 2.0.0
@@ -6539,12 +6510,6 @@ packages:
     dev: true
     resolution:
       integrity: sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=
-  /mri/1.1.5:
-    dev: false
-    engines:
-      node: '>=4'
-    resolution:
-      integrity: sha512-d2RKzMD4JNyHMbnbWnznPaa8vbdlq/4pNZ3IgdaGrVbBhebBsGUUE/6qorTMYNS6TwuH3ilfOlD2bf4Igh8CKg==
   /ms/2.0.0:
     resolution:
       integrity: sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
@@ -8152,14 +8117,6 @@ packages:
       npm: '>=2.0.0'
     resolution:
       integrity: sha512-3HMA8z/Oz61DUHe+SdOiQyzIf4tOx5oQHmMir7IZEu6TMqCLHT4LRcmNaUS0NwOz8VLvmmBduMsoaUvMaIiqzg==
-  /sade/1.7.3:
-    dependencies:
-      mri: 1.1.5
-    dev: false
-    engines:
-      node: '>= 6'
-    resolution:
-      integrity: sha512-m4BctppMvJ60W1dXnHq7jMmFe3hPJZDAH85kQ3ACTo7XZNVUuTItCQ+2HfyaMeV5cKrbw7l4vD/6We3GBxvdJw==
   /safe-buffer/5.1.1:
     dev: true
     resolution:
@@ -8401,21 +8358,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-9no0pK7/1y+8/oTF3sy/+kx0PjQ3uk4cYwld5F1CJGk2gx+prRyUq8GRfvcVLq5niYWSozZdX73a2wIr1o9l/g==
-  /sirv-cli/0.4.6:
-    dependencies:
-      console-clear: 1.1.1
-      get-port: 3.2.0
-      kleur: 3.0.3
-      local-access: 1.0.1
-      sade: 1.7.3
-      sirv: 0.4.6
-      tinydate: 1.3.0
-    dev: false
-    engines:
-      node: '>= 6'
-    hasBin: true
-    resolution:
-      integrity: sha512-/Vj85/kBvPL+n9ibgX6FicLE8VjidC1BhlX67PYPBfbBAphzR6i0k0HtU5c2arejfU3uzq8l3SYPCwl1x7z6Ww==
   /sirv/0.4.6:
     dependencies:
       '@polka/url': 0.5.0
@@ -9008,12 +8950,6 @@ packages:
     optional: true
     resolution:
       integrity: sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
-  /tinydate/1.3.0:
-    dev: false
-    engines:
-      node: '>=4'
-    resolution:
-      integrity: sha512-7cR8rLy2QhYHpsBDBVYnnWXm8uRTr38RoZakFSW7Bs7PzfMPNZthuMLkwqZv7MTu8lhQ91cOFYS5a7iFj2oR3w==
   /tmp/0.0.33:
     dependencies:
       os-tmpdir: 1.0.2

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -19,15 +19,11 @@
     "@storybook/addons": "^5.3.19",
     "@storybook/svelte": "^5.3.19",
     "babel-loader": "^8.1.0",
-    "classnames": "^2.2.6",
     "rollup": "^1.20.0",
     "rollup-plugin-livereload": "^1.0.0",
     "rollup-plugin-svelte": "^5.2.2",
     "rollup-plugin-terser": "^5.1.2",
     "svelte": "^3.23.2",
     "svelte-loader": "^2.13.6"
-  },
-  "dependencies": {
-    "sirv-cli": "^0.4.4"
   }
 }

--- a/projects/components/src/components/ig-image/index.svelte
+++ b/projects/components/src/components/ig-image/index.svelte
@@ -1,5 +1,4 @@
 <script>
-  import classnames from "classnames";
   export let src;
   export let message;
 
@@ -51,8 +50,5 @@
   <div class="image__container">
     <img {src} alt="instagram style" on:click={onImageClicked} />
   </div>
-  <div
-    class={classnames({ message: true, 'message--image-clicked': isClicked })}>
-    {message}
-  </div>
+  <div class:message class:message--image-clicked={isClicked}>{message}</div>
 </div>


### PR DESCRIPTION
### remove `sirv-cli` and `classnames`

- removing `sirv-cli` as it's just a component library
- no need for `classnames` as svelte inbuilt class system is cool enough